### PR TITLE
Basic KV Lang Widget Setup

### DIFF
--- a/spotify_widget.kv
+++ b/spotify_widget.kv
@@ -1,0 +1,15 @@
+#:kivy 
+
+<SpotifyWidget>:
+    Label:
+        id: song_title
+        text: ""
+        font_size: '25sp'
+    Label: 
+        id: artist
+        text: ""
+        font_size: '20sp'
+    Label:
+        id: album 
+        text: ""
+        font_size: '20sp'


### PR DESCRIPTION
A very basic structure for the Spotify Widget. Includes a label for Song Title, Artist, and Album. Still needs proper formatting and alignment, however, it will work for a basic start. 